### PR TITLE
fix: undefined import

### DIFF
--- a/src/as-tral.ts
+++ b/src/as-tral.ts
@@ -162,7 +162,7 @@ async function benchWASM(info: Info, binary: Uint8Array) {
     let currentBench = "";
     const { instance: { exports } } = await WebAssembly.instantiate(binary, {
         __astral__: {
-            now: performance.now,
+            now: () => performance.now(),
             warmup(descriptor: number) {
                 currentBench = info.enumeration[descriptor];
                 console.log();


### PR DESCRIPTION
Hey, rom.
Seems like there is an issue with the import here. `now: performance.now` results in `now` being `undefined`.
This PR fixes that by making `performance.now()` into a closure.
Stdout below:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "this" argument must be an instance of Performance. Received undefined
    at now (node:internal/perf/performance:139:5)
    at wasm://wasm/0001824a:wasm-function[26]:0x1453
    at wasm://wasm/0001824a:wasm-function[44]:0x3c80
    at wasm://wasm/0001824a:wasm-function[45]:0x3ccf
    at benchWASM (file:///home/jairussw/Code/AssemblyScript/as-json/node_modules/@as-tral/cli/dist/as-tral.js:303:13)
    at async compileFile (file:///home/jairussw/Code/AssemblyScript/as-json/node_modules/@as-tral/cli/dist/as-tral.js:132:5)
    at async file:///home/jairussw/Code/AssemblyScript/as-json/node_modules/@as-tral/cli/dist/as-tral.js:56:5 {
  code: 'ERR_INVALID_ARG_TYPE'
}
```